### PR TITLE
Use quite mode to only show errors

### DIFF
--- a/.github/workflows/broken_link.yml
+++ b/.github/workflows/broken_link.yml
@@ -15,5 +15,6 @@ jobs:
     - uses: actions/checkout@master
       with:
         fetch-depth: 1
-    - uses: gaurav-nelson/github-action-markdown-link-check@0.4.0
-
+    - uses: gaurav-nelson/github-action-markdown-link-check@0.5.0
+      with:
+        use-quite-mode: 'yes'

--- a/markdown/about.md
+++ b/markdown/about.md
@@ -11,7 +11,7 @@ The core team members who administer the nf-core project are listed below:
 * [@olgabot](https://github.com/olgabot): Olga Botvinnik
 * [@sven1103](https://github.com/sven1103): Sven F.
 
-We regularly review members - if you'd like to be involved, drop us a line on Slack.
+We regularly review members - if you'd like to be involved, drop us a message on Slack.
 
 ## History {#history}
 The nf-core project came about at the start of 2018. [Phil Ewels](http://phil.ewels.co.uk/) ([@ewels](https://github.com/ewels/)) was the head of the development facility at [NGI Stockholm](https://ngisweden.scilifelab.se/) (National Genomics Infrastructure), part of [SciLifeLab](https://www.scilifelab.se/) in Sweden.


### PR DESCRIPTION
- Use the latest version of github-action-markdown-link-check
- Use quite mode (to show errors only)